### PR TITLE
Fixes for redundant logo downloads and abandoned resources.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,11 @@
 {
-  "plugins": ["transform-react-jsx"]
+  "plugins": ["transform-react-jsx"],
+  "env": {
+    "development": {
+      "plugins": ["transform-es2015-modules-commonjs"]
+    },
+    "test": {
+      "plugins": ["transform-es2015-modules-commonjs"]
+    }
+  }
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ install:
 - npm install
 script:
 - npm run-script build
+- npm run-script test
 deploy:
   provider: npm
   skip_cleanup: true

--- a/__tests__/FulfillerLogo.test.js
+++ b/__tests__/FulfillerLogo.test.js
@@ -1,0 +1,19 @@
+'use strict';
+
+import React from 'react';
+import renderer from 'react-test-renderer';
+
+jest.mock('react-visibility-sensor', () => 'div');
+
+import FulfillerLogo from '../src/FufillerLogo.jsx';
+
+describe('FulfillerLogo', function () {
+
+  it('renders correctly', () => {
+    const tree = renderer
+      .create(<FulfillerLogo/>)
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+});

--- a/__tests__/__snapshots__/FulfillerLogo.test.js.snap
+++ b/__tests__/__snapshots__/FulfillerLogo.test.js.snap
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FulfillerLogo renders correctly 1`] = `
+<div
+  onChange={[Function]}
+  partialVisibility={true}
+  scrollCheck={true}
+  scrollDelay={1000}
+>
+  <div
+    style={
+      Object {
+        "alignContent": "center",
+        "height": "50px",
+        "marginRight": "10px",
+        "maxHeight": "50px",
+        "maxWidth": "50px",
+        "objectFit": "contain",
+        "verticalAlign": "middle",
+        "width": "50px",
+      }
+    }
+  >
+    <span />
+  </div>
+</div>
+`;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Fetches fulfiller logo from Fulfiller Identity Service.",
   "main": "./lib/index.js",
   "scripts": {
-    "build": "babel src -d lib"
+    "build": "babel src -d lib",
+    "test": "jest"
   },
   "repository": {
     "type": "git",
@@ -17,6 +18,17 @@
   "files": [
     "lib"
   ],
+  "jest": {
+    "verbose": true,
+    "moduleDirectories": [
+      "node_modules",
+      "src"
+    ],
+    "moduleFileExtensions": [
+      "js",
+      "jsx"
+    ]
+  },
   "bugs": {
     "url": "https://github.com/Cimpress-MCP/react-cimpress-fulfiller-logo/issues"
   },
@@ -26,10 +38,16 @@
   "devDependencies": {
     "babel": "^6.23.0",
     "babel-cli": "^6.24.1",
-    "babel-plugin-transform-react-jsx": "^6.24.1"
+    "babel-plugin-transform-es2015-modules-commonjs": "^6.26.0",
+    "babel-plugin-transform-react-jsx": "^6.24.1",
+    "jest": "^21.2.1",
+    "jest-cli": "^21.2.1",
+    "react": "^16.2.0",
+    "react-dom": "^16.2.0",
+    "react-test-renderer": "^16.2.0"
   },
   "dependencies": {
     "prop-types": "^15.6.0",
-    "react-visibility-sensor": "^3.10.1"
+    "react-visibility-sensor": "^3.11.0"
   }
 }


### PR DESCRIPTION
Fix for #6 and #7. Provides cleanup of browser resources on component unmount, does not keep retrying to load logo if the fulfiller does not have a logo (or if one does not have access)