### PR TITLE
New babel env preset

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,11 +1,8 @@
 {
-  "plugins": ["transform-react-jsx"],
-  "env": {
-    "development": {
-      "plugins": ["transform-es2015-modules-commonjs"]
-    },
-    "test": {
-      "plugins": ["transform-es2015-modules-commonjs"]
-    }
-  }
+  "presets": [
+    "env"
+  ],
+  "plugins": [
+    "transform-react-jsx"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-cimpress-fulfiller-logo",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "description": "Fetches fulfiller logo from Fulfiller Identity Service.",
   "main": "./lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
   "devDependencies": {
     "babel": "^6.23.0",
     "babel-cli": "^6.24.1",
-    "babel-plugin-transform-es2015-modules-commonjs": "^6.26.0",
     "babel-plugin-transform-react-jsx": "^6.24.1",
+    "babel-preset-env": "^1.6.1",
     "jest": "^21.2.1",
     "jest-cli": "^21.2.1",
     "react": "^16.2.0",


### PR DESCRIPTION
The last transpiling approach was not transpiling the classes. Using the babel presset env instead, which is the recommended presset by babel.